### PR TITLE
Fix posthog client self is not defined error

### DIFF
--- a/src/providers/posthog/client.ts
+++ b/src/providers/posthog/client.ts
@@ -9,6 +9,11 @@ declare global {
 	}
 }
 
+// Helper function to check if we're in a browser environment
+function isBrowser(): boolean {
+	return typeof window !== "undefined" && typeof window.document !== "undefined";
+}
+
 export class PostHogClientProvider extends BaseAnalyticsProvider {
 	name = "PostHog-Client";
 	private posthog?: PostHog;
@@ -23,6 +28,12 @@ export class PostHogClientProvider extends BaseAnalyticsProvider {
 	async initialize(): Promise<void> {
 		if (!this.isEnabled()) return;
 		if (this.initialized) return;
+
+		// Check if we're in a browser environment
+		if (!isBrowser()) {
+			this.log("PostHog client provider can only be used in browser environments");
+			return;
+		}
 
 		// Validate config has required fields
 		if (!this.config.apiKey || typeof this.config.apiKey !== "string") {


### PR DESCRIPTION
Add environment detection to PostHog client initialization to prevent `ReferenceError: self is not defined` in Node.js environments.

The `posthog-js` library contains browser-specific code that executes on import, leading to errors when the `@stacksee/analytics` package is used in non-browser environments (e.g., during SSR or Node.js tests). This change ensures the PostHog client only initializes when `window` and `document` are available.

---

[Open in Web](https://cursor.com/agents?id=bc-fb89fe2e-f265-4a26-80f9-ecd00b2f9dce) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-fb89fe2e-f265-4a26-80f9-ecd00b2f9dce)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)