### PR TITLE
Add OpenPanel client and server providers

### DIFF
--- a/.changeset/bright-panels-track.md
+++ b/.changeset/bright-panels-track.md
@@ -1,0 +1,5 @@
+---
+"trakoo": minor
+---
+
+Add OpenPanel client and server providers with event tracking, user identification, page views, and safe server-side identity isolation.

--- a/.changeset/fresh-paths-stay.md
+++ b/.changeset/fresh-paths-stay.md
@@ -1,0 +1,5 @@
+---
+"trakoo": patch
+---
+
+Preserve page-path metadata on OpenPanel client events tracked before a page view.

--- a/package.json
+++ b/package.json
@@ -92,6 +92,8 @@
 	"optionalDependencies": {
 		"@bentonow/bento-node-sdk": "^0.2.1",
 		"@emitkit/js": "^2.1.0",
+		"@openpanel/sdk": "^1.3.1",
+		"@openpanel/web": "^1.4.1",
 		"posthog-js": "^1.268.2",
 		"posthog-node": "^5.9.0"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,12 @@ importers:
       '@emitkit/js':
         specifier: ^2.1.0
         version: 2.1.0
+      '@openpanel/sdk':
+        specifier: ^1.3.1
+        version: 1.3.1
+      '@openpanel/web':
+        specifier: ^1.4.1
+        version: 1.4.1
       posthog-js:
         specifier: ^1.268.2
         version: 1.268.2
@@ -1318,6 +1324,12 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@openpanel/sdk@1.3.1':
+    resolution: {integrity: sha512-mQ5xaBUGXnyRg3qYxwnbVaUYyW7w8u+munrWk/ClnqxEeR2j+FYPiA6noHbHMCFC2aZutYD5OoRzEvw3FBNFxw==}
+
+  '@openpanel/web@1.4.1':
+    resolution: {integrity: sha512-DgUWeocZw+b57YiJjefZPg+6sceR7TdOF8x7Ut75lu3CwcwqGi5jZNPXjikNemGL37aNWXCB4buhcoNan2j7RA==}
+
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
@@ -1627,6 +1639,12 @@ packages:
     resolution: {integrity: sha512-Wq2zpapRYLfi4aKxf2Xff0tN+7slj2d4R87WEzqw7ZLsVvO5zwYCIuEGSZYiK41+GlwUo1HiR+GdkLEJnCKTCw==}
     cpu: [x64]
     os: [win32]
+
+  '@rrweb/types@2.0.0-alpha.20':
+    resolution: {integrity: sha512-RbnDgKxA/odwB1R4gF7eUUj+rdSrq6ROQJsnMw7MIsGzlbSYvJeZN8YY4XqU0G6sKJvXI6bSzk7w/G94jNwzhw==}
+
+  '@rrweb/utils@2.1.1':
+    resolution: {integrity: sha512-x2SgJAD3YJ9eVcLZ5l6OqWMtczdA3VfS5XqPeqpZdQgV9oh6Id5GK2cDN4bimnkqryOcIJdz8cTvV0yNvqQ+nA==}
 
   '@rushstack/node-core-library@5.13.1':
     resolution: {integrity: sha512-5yXhzPFGEkVc9Fu92wsNJ9jlvdwz4RNb2bMso+/+TH0nMm1jDDDsOIf4l8GAkPxGuwPw5DH24RliWVfSPhlW/Q==}
@@ -1938,6 +1956,9 @@ packages:
 
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
+  '@types/css-font-loading-module@0.0.7':
+    resolution: {integrity: sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==}
 
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
@@ -2286,6 +2307,9 @@ packages:
   '@vue/shared@3.5.15':
     resolution: {integrity: sha512-bKvgFJJL1ZX9KxMCTQY6xD9Dhe3nusd1OhyOb1cJYGqvAr0Vg8FIjHPMOEVbJ9GDT9HG+Bjdn4oS8ohKP8EvoA==}
 
+  '@xstate/fsm@1.6.5':
+    resolution: {integrity: sha512-b5o1I6aLNeYlU/3CPlj/Z91ybk1gUsKT+5NAJI+2W4UjvS5KLG28K9v5UvNoFVjHV8PajVZ00RH3vnjyQO7ZAw==}
+
   abbrev@3.0.1:
     resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -2449,6 +2473,10 @@ packages:
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
+
+  base64-arraybuffer@1.0.2:
+    resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
+    engines: {node: '>= 0.6.0'}
 
   baseline-browser-mapping@2.10.44:
     resolution: {integrity: sha512-T3ghW+sl/ZJ8w1v/yQx3qvJ9040DWoLBz8JT/CILbAKcFyG9b2MRe75v6W5uXjv6uH1lumK2Kv46y2zSkcej0Q==}
@@ -4208,6 +4236,9 @@ packages:
     resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
     engines: {node: '>= 18'}
 
+  mitt@3.0.1:
+    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
+
   mlly@1.7.4:
     resolution: {integrity: sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==}
 
@@ -4763,8 +4794,17 @@ packages:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
 
+  rrdom@2.1.1:
+    resolution: {integrity: sha512-VBkTF3bGNqcZjqnbo/gKi9GVQPIxiG0dofw7CQdAZQFQ2juJdt2YKIf3oS9QudL8HTpGh9bz5TUN+3amBn1Geg==}
+
   rrweb-cssom@0.8.0:
     resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
+  rrweb-snapshot@2.1.1:
+    resolution: {integrity: sha512-al4Kx7Am7YlIn/5Yb2EMr7cdmjGiK+cLhdilJEXqkFXgpnys8t/yMJumXy2Ormgirpg3MBnFha0GTgny+iIL2w==}
+
+  rrweb@2.0.0-alpha.20:
+    resolution: {integrity: sha512-CZKDlm+j1VA50Ko3gnMbpvguCAleljsTNXPnVk9aeNP8o6T6kolRbISHyDZpqZ4G+bdDLlQOignPP3jEsXs8Gg==}
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -6976,6 +7016,16 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
+  '@openpanel/sdk@1.3.1':
+    optional: true
+
+  '@openpanel/web@1.4.1':
+    dependencies:
+      '@openpanel/sdk': 1.3.1
+      '@rrweb/types': 2.0.0-alpha.20
+      rrweb: 2.0.0-alpha.20
+    optional: true
+
   '@opentelemetry/api@1.9.0': {}
 
   '@orama/orama@3.1.18': {}
@@ -7167,6 +7217,12 @@ snapshots:
     optional: true
 
   '@rollup/rollup-win32-x64-msvc@4.41.1':
+    optional: true
+
+  '@rrweb/types@2.0.0-alpha.20':
+    optional: true
+
+  '@rrweb/utils@2.1.1':
     optional: true
 
   '@rushstack/node-core-library@5.13.1(@types/node@20.17.51)':
@@ -7480,6 +7536,9 @@ snapshots:
   '@types/babel__traverse@7.28.0':
     dependencies:
       '@babel/types': 7.29.7
+
+  '@types/css-font-loading-module@0.0.7':
+    optional: true
 
   '@types/d3-array@3.2.2': {}
 
@@ -7890,6 +7949,9 @@ snapshots:
 
   '@vue/shared@3.5.15': {}
 
+  '@xstate/fsm@1.6.5':
+    optional: true
+
   abbrev@3.0.1: {}
 
   abort-controller@3.0.0:
@@ -8119,6 +8181,9 @@ snapshots:
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
+
+  base64-arraybuffer@1.0.2:
+    optional: true
 
   baseline-browser-mapping@2.10.44: {}
 
@@ -10345,6 +10410,9 @@ snapshots:
     dependencies:
       minipass: 7.1.2
 
+  mitt@3.0.1:
+    optional: true
+
   mlly@1.7.4:
     dependencies:
       acorn: 8.14.1
@@ -10962,7 +11030,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  rrdom@2.1.1:
+    dependencies:
+      rrweb-snapshot: 2.1.1
+    optional: true
+
   rrweb-cssom@0.8.0: {}
+
+  rrweb-snapshot@2.1.1:
+    dependencies:
+      postcss: 8.5.20
+    optional: true
+
+  rrweb@2.0.0-alpha.20:
+    dependencies:
+      '@rrweb/types': 2.0.0-alpha.20
+      '@rrweb/utils': 2.1.1
+      '@types/css-font-loading-module': 0.0.7
+      '@xstate/fsm': 1.6.5
+      base64-arraybuffer: 1.0.2
+      mitt: 3.0.1
+      rrdom: 2.1.1
+      rrweb-snapshot: 2.1.1
+    optional: true
 
   run-parallel@1.2.0:
     dependencies:

--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,7 @@ The library includes built-in support for popular analytics services, with more 
 | Provider | Type | Documentation |
 |----------|------|---------------|
 | **PostHog** | Product Analytics | [View Docs](https://stacksee-analytics.vercel.app/docs/providers/posthog) |
+| **OpenPanel** | Web & Product Analytics | [View Docs](https://stacksee-analytics.vercel.app/docs/providers/openpanel) |
 | **Bento** | Email Marketing & Events | [View Docs](https://stacksee-analytics.vercel.app/docs/providers/bento) |
 | **Pirsch** | Privacy-Focused Web Analytics | [View Docs](https://stacksee-analytics.vercel.app/docs/providers/pirsch) |
 
@@ -57,6 +58,9 @@ pnpm install trakoo
 
 # For PostHog support
 pnpm install posthog-js posthog-node
+
+# For OpenPanel support
+pnpm install @openpanel/web @openpanel/sdk
 
 # For Bento support (server-side only)
 pnpm install @bentonow/bento-node-sdk

--- a/src/providers/client.ts
+++ b/src/providers/client.ts
@@ -7,6 +7,10 @@ export { PostHogClientProvider } from "./posthog/client.js";
 // PostHog client types only
 export type { PostHogConfig } from "posthog-js";
 
+// OpenPanel client provider
+export { OpenPanelClientProvider } from "./openpanel/client.js";
+export type { OpenPanelClientConfig } from "./openpanel/client.js";
+
 // Bento client provider
 export { BentoClientProvider } from "./bento/client.js";
 export type { BentoClientConfig } from "./bento/client.js";

--- a/src/providers/openpanel/client.ts
+++ b/src/providers/openpanel/client.ts
@@ -1,0 +1,183 @@
+import type { BaseEvent, EventContext } from "@/core/events/types.js";
+import { BaseAnalyticsProvider } from "@/providers/base.provider.js";
+import {
+	buildEventProperties,
+	buildIdentifyPayload,
+	buildTrackedEventProperties,
+} from "@/providers/openpanel/shared.js";
+import { isBrowser } from "@/utils/environment.js";
+import type {
+	OpenPanel as OpenPanelWebClient,
+	OpenPanelOptions as OpenPanelWebOptions,
+} from "@openpanel/web";
+
+export type OpenPanelClientConfig = Omit<
+	OpenPanelWebOptions,
+	| "clientSecret"
+	| "debug"
+	| "disabled"
+	| "sdk"
+	| "sdkVersion"
+	| "waitForProfile"
+> & {
+	clientId: string;
+	debug?: boolean;
+	enabled?: boolean;
+};
+
+export class OpenPanelClientProvider extends BaseAnalyticsProvider {
+	name = "OpenPanel-Client";
+	private client?: OpenPanelWebClient;
+	private config: OpenPanelClientConfig;
+	private initialized = false;
+	private initPromise?: Promise<void>;
+	private pendingActions: Array<() => void> = [];
+
+	constructor(config: OpenPanelClientConfig) {
+		super({ debug: config.debug, enabled: config.enabled });
+		this.config = config;
+	}
+
+	initialize(): Promise<void> {
+		if (!this.isEnabled() || this.initialized) return Promise.resolve();
+		if (this.initPromise) return this.initPromise;
+
+		this.initPromise = this.doInitialize();
+		return this.initPromise;
+	}
+
+	private async doInitialize(): Promise<void> {
+		if (!isBrowser()) {
+			this.log("Skipping initialization - not in browser environment");
+			return;
+		}
+
+		if (!this.config.clientId || typeof this.config.clientId !== "string") {
+			this.initPromise = undefined;
+			throw new Error("OpenPanel requires a clientId");
+		}
+
+		try {
+			const { OpenPanel } = await import("@openpanel/web");
+			const runtimeConfig = this.config as OpenPanelClientConfig &
+				Partial<
+					Pick<
+						OpenPanelWebOptions,
+						| "clientSecret"
+						| "disabled"
+						| "sdk"
+						| "sdkVersion"
+						| "waitForProfile"
+					>
+				>;
+			const {
+				enabled,
+				clientSecret,
+				disabled,
+				sdk,
+				sdkVersion,
+				waitForProfile,
+				...options
+			} = runtimeConfig;
+			void enabled;
+			void clientSecret;
+			void disabled;
+			void sdk;
+			void sdkVersion;
+			void waitForProfile;
+
+			this.client = new OpenPanel({
+				trackAttributes: false,
+				trackOutgoingLinks: false,
+				trackScreenViews: false,
+				...options,
+				debug: this.config.debug ?? false,
+			});
+			this.initialized = true;
+			this.flushPendingActions();
+			this.log("Initialized successfully");
+		} catch (error) {
+			this.initPromise = undefined;
+			this.pendingActions = [];
+			console.error("[OpenPanel-Client] Failed to initialize:", error);
+			throw error;
+		}
+	}
+
+	private runWhenInitialized(action: () => void): void {
+		if (!this.isEnabled()) return;
+		if (this.initialized && this.client) {
+			action();
+			return;
+		}
+		if (this.initPromise) {
+			this.pendingActions.push(action);
+		}
+	}
+
+	private flushPendingActions(): void {
+		const actions = this.pendingActions;
+		this.pendingActions = [];
+		for (const action of actions) {
+			try {
+				action();
+			} catch (error) {
+				console.error("[OpenPanel-Client] Pending action failed:", error);
+			}
+		}
+	}
+
+	identify(userId: string, traits?: Record<string, unknown>): void {
+		this.runWhenInitialized(() => {
+			const pending = this.client?.identify(
+				buildIdentifyPayload(userId, traits),
+			);
+			if (pending) {
+				void pending.catch((error) => {
+					console.error("[OpenPanel-Client] Failed to identify user:", error);
+				});
+			}
+			this.log("Identified user", { userId, traits });
+		});
+	}
+
+	async track(event: BaseEvent, context?: EventContext): Promise<void> {
+		if (!this.isEnabled()) return;
+		if (!this.initialized && this.initPromise) await this.initPromise;
+		if (!this.initialized || !this.client) return;
+
+		await this.client.track(
+			event.action,
+			buildTrackedEventProperties(event, context),
+		);
+		this.log("Tracked event", { event, context });
+	}
+
+	pageView(properties?: Record<string, unknown>, context?: EventContext): void {
+		this.runWhenInitialized(() => {
+			const pageProperties = buildEventProperties(properties, context, {});
+			const path = context?.page?.url ?? context?.page?.path;
+			if (path) {
+				this.client?.screenView(path, pageProperties);
+			} else {
+				this.client?.screenView(pageProperties);
+			}
+			this.log("Tracked page view", { properties, context });
+		});
+	}
+
+	pageLeave(
+		_properties?: Record<string, unknown>,
+		_context?: EventContext,
+	): void {
+		this.log("Page leave is not supported by OpenPanel");
+	}
+
+	reset(): void {
+		this.pendingActions = [];
+		if (!this.isEnabled() || !this.initialized || !this.client) return;
+
+		this.client.clear();
+		this.log("Cleared user identity");
+	}
+}

--- a/src/providers/openpanel/client.ts
+++ b/src/providers/openpanel/client.ts
@@ -28,6 +28,7 @@ export type OpenPanelClientConfig = Omit<
 export class OpenPanelClientProvider extends BaseAnalyticsProvider {
 	name = "OpenPanel-Client";
 	private client?: OpenPanelWebClient;
+	private trackEvent?: OpenPanelWebClient["track"];
 	private config: OpenPanelClientConfig;
 	private initialized = false;
 	private initPromise?: Promise<void>;
@@ -58,7 +59,7 @@ export class OpenPanelClientProvider extends BaseAnalyticsProvider {
 		}
 
 		try {
-			const { OpenPanel } = await import("@openpanel/web");
+			const { OpenPanel, OpenPanelBase } = await import("@openpanel/web");
 			const runtimeConfig = this.config as OpenPanelClientConfig &
 				Partial<
 					Pick<
@@ -93,6 +94,8 @@ export class OpenPanelClientProvider extends BaseAnalyticsProvider {
 				...options,
 				debug: this.config.debug ?? false,
 			});
+			// The web override replaces a caller-supplied __path with its last screen view.
+			this.trackEvent = OpenPanelBase.prototype.track.bind(this.client);
 			this.initialized = true;
 			this.flushPendingActions();
 			this.log("Initialized successfully");
@@ -144,9 +147,9 @@ export class OpenPanelClientProvider extends BaseAnalyticsProvider {
 	async track(event: BaseEvent, context?: EventContext): Promise<void> {
 		if (!this.isEnabled()) return;
 		if (!this.initialized && this.initPromise) await this.initPromise;
-		if (!this.initialized || !this.client) return;
+		if (!this.initialized || !this.trackEvent) return;
 
-		await this.client.track(
+		await this.trackEvent(
 			event.action,
 			buildTrackedEventProperties(event, context),
 		);

--- a/src/providers/openpanel/server.ts
+++ b/src/providers/openpanel/server.ts
@@ -1,0 +1,127 @@
+import type { BaseEvent, EventContext } from "@/core/events/types.js";
+import { BaseAnalyticsProvider } from "@/providers/base.provider.js";
+import {
+	buildEventProperties,
+	buildIdentifyPayload,
+	buildTrackedEventProperties,
+} from "@/providers/openpanel/shared.js";
+import { OpenPanel, type OpenPanelOptions } from "@openpanel/sdk";
+
+export interface OpenPanelServerConfig {
+	clientId: string;
+	clientSecret: string;
+	apiUrl?: string;
+	filter?: OpenPanelOptions["filter"];
+	debug?: boolean;
+	enabled?: boolean;
+}
+
+export class OpenPanelServerProvider extends BaseAnalyticsProvider {
+	name = "OpenPanel-Server";
+	private client?: OpenPanel;
+	private config: OpenPanelServerConfig;
+	private initialized = false;
+
+	constructor(config: OpenPanelServerConfig) {
+		super({ debug: config.debug, enabled: config.enabled });
+		this.config = config;
+	}
+
+	initialize(): void {
+		if (!this.isEnabled() || this.initialized) return;
+		if (!this.config.clientId || typeof this.config.clientId !== "string") {
+			throw new Error("OpenPanel requires a clientId");
+		}
+		if (
+			!this.config.clientSecret ||
+			typeof this.config.clientSecret !== "string"
+		) {
+			throw new Error("OpenPanel requires a clientSecret on the server");
+		}
+
+		try {
+			const { enabled, ...options } = this.config;
+			void enabled;
+
+			this.client = new OpenPanel(options);
+			this.initialized = true;
+			this.log("Initialized successfully");
+		} catch (error) {
+			console.error("[OpenPanel-Server] Failed to initialize:", error);
+			throw error;
+		}
+	}
+
+	async identify(
+		userId: string,
+		traits?: Record<string, unknown>,
+	): Promise<void> {
+		const client =
+			this.isEnabled() && this.initialized ? this.client : undefined;
+		if (!client) return;
+
+		let pending: ReturnType<OpenPanel["identify"]>;
+		try {
+			pending = client.identify(buildIdentifyPayload(userId, traits));
+		} finally {
+			client.clear();
+		}
+		await pending;
+		this.log("Updated user profile", { userId, traits });
+	}
+
+	async track(event: BaseEvent, context?: EventContext): Promise<void> {
+		const client =
+			this.isEnabled() && this.initialized ? this.client : undefined;
+		if (!client) return;
+
+		await client.track(
+			event.action,
+			buildTrackedEventProperties(event, context),
+		);
+		this.log("Tracked event", { event, context });
+	}
+
+	async pageView(
+		properties?: Record<string, unknown>,
+		context?: EventContext,
+	): Promise<void> {
+		const client =
+			this.isEnabled() && this.initialized ? this.client : undefined;
+		if (!client) return;
+
+		await client.track(
+			"screen_view",
+			buildEventProperties(properties, context, {
+				category: "navigation",
+				userId: context?.user?.userId,
+			}),
+		);
+		this.log("Tracked page view", { properties, context });
+	}
+
+	pageLeave(
+		_properties?: Record<string, unknown>,
+		_context?: EventContext,
+	): void {
+		this.log("Page leave is not supported by OpenPanel");
+	}
+
+	reset(): void {
+		if (!this.isEnabled() || !this.initialized || !this.client) return;
+
+		this.client.clear();
+		this.log("Cleared user identity");
+	}
+
+	shutdown(): void {
+		const client =
+			this.isEnabled() && this.initialized ? this.client : undefined;
+		if (!client) return;
+
+		client.clear();
+		this.client = undefined;
+		this.initialized = false;
+		this.log("Shutdown complete");
+	}
+}

--- a/src/providers/openpanel/shared.ts
+++ b/src/providers/openpanel/shared.ts
@@ -1,0 +1,75 @@
+import type { BaseEvent, EventContext } from "@/core/events/types.js";
+import type { IdentifyPayload } from "@openpanel/sdk";
+
+const PROFILE_FIELDS = ["firstName", "lastName", "email", "avatar"] as const;
+
+export function buildIdentifyPayload(
+	userId: string,
+	traits?: Record<string, unknown>,
+): IdentifyPayload {
+	const payload: IdentifyPayload = { profileId: userId };
+	const properties: Record<string, unknown> = {};
+
+	for (const [key, value] of Object.entries(traits ?? {})) {
+		if (
+			PROFILE_FIELDS.includes(key as (typeof PROFILE_FIELDS)[number]) &&
+			typeof value === "string"
+		) {
+			if (key === "firstName") payload.firstName = value;
+			if (key === "lastName") payload.lastName = value;
+			if (key === "email") payload.email = value;
+			if (key === "avatar") payload.avatar = value;
+		} else {
+			properties[key] = value;
+		}
+	}
+
+	if (Object.keys(properties).length > 0) {
+		payload.properties = properties;
+	}
+
+	return payload;
+}
+
+export function buildEventProperties(
+	properties: Record<string, unknown> | undefined,
+	context: EventContext | undefined,
+	metadata: {
+		category?: string;
+		timestamp?: number;
+		userId?: string;
+		sessionId?: string;
+	},
+): Record<string, unknown> {
+	const pagePath = context?.page?.url ?? context?.page?.path;
+
+	return {
+		...properties,
+		...(metadata.category && { category: metadata.category }),
+		...(metadata.timestamp !== undefined && {
+			__timestamp: new Date(metadata.timestamp).toISOString(),
+		}),
+		...(metadata.userId && { profileId: metadata.userId }),
+		...(metadata.sessionId && { sessionId: metadata.sessionId }),
+		...(pagePath && { __path: pagePath }),
+		...(context?.page?.title && { __title: context.page.title }),
+		...(context?.page?.referrer && { __referrer: context.page.referrer }),
+		...(context?.page && { page: context.page }),
+		...(context?.device && { device: context.device }),
+		...(context?.utm && { utm: context.utm }),
+		...(context?.user?.email && { user_email: context.user.email }),
+		...(context?.user?.traits && { user_traits: context.user.traits }),
+	};
+}
+
+export function buildTrackedEventProperties(
+	event: BaseEvent,
+	context?: EventContext,
+): Record<string, unknown> {
+	return buildEventProperties(event.properties, context, {
+		category: event.category,
+		timestamp: event.timestamp,
+		userId: event.userId ?? context?.user?.userId,
+		sessionId: event.sessionId,
+	});
+}

--- a/src/providers/server.ts
+++ b/src/providers/server.ts
@@ -5,6 +5,10 @@ export { PostHogServerProvider } from "./posthog/server.js";
 // PostHog server types only
 export type { PostHogOptions } from "posthog-node";
 
+// OpenPanel server provider
+export { OpenPanelServerProvider } from "./openpanel/server.js";
+export type { OpenPanelServerConfig } from "./openpanel/server.js";
+
 // Bento server provider
 export { BentoServerProvider } from "./bento/server.js";
 export type {

--- a/test/openpanel-client-provider.test.ts
+++ b/test/openpanel-client-provider.test.ts
@@ -1,0 +1,238 @@
+/** @vitest-environment jsdom */
+import { OpenPanelClientProvider } from "@/providers/openpanel/client.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { constructorSpy, sdk } = vi.hoisted(() => ({
+	constructorSpy: vi.fn(),
+	sdk: {
+		identify: vi.fn(),
+		track: vi.fn(),
+		screenView: vi.fn(),
+		clear: vi.fn(),
+	},
+}));
+
+vi.mock("@openpanel/web", () => ({
+	OpenPanel: class {
+		identify = sdk.identify;
+		track = sdk.track;
+		screenView = sdk.screenView;
+		clear = sdk.clear;
+
+		constructor(config: unknown) {
+			constructorSpy(config);
+		}
+	},
+}));
+
+describe("OpenPanelClientProvider", () => {
+	beforeEach(() => {
+		constructorSpy.mockClear();
+		for (const mock of Object.values(sdk)) mock.mockReset();
+		sdk.track.mockResolvedValue(null);
+		sdk.identify.mockResolvedValue(null);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("initializes once with explicit auto-capture defaults", async () => {
+		const provider = new OpenPanelClientProvider({ clientId: "client-id" });
+
+		await Promise.all([provider.initialize(), provider.initialize()]);
+
+		expect(provider.name).toBe("OpenPanel-Client");
+		expect(constructorSpy).toHaveBeenCalledTimes(1);
+		expect(constructorSpy).toHaveBeenCalledWith({
+			clientId: "client-id",
+			debug: false,
+			trackAttributes: false,
+			trackOutgoingLinks: false,
+			trackScreenViews: false,
+		});
+	});
+
+	it("forwards safe web options without provider-only fields", async () => {
+		const filter = vi.fn(() => true);
+		const provider = new OpenPanelClientProvider({
+			clientId: "client-id",
+			apiUrl: "https://openpanel.example.com",
+			debug: true,
+			enabled: true,
+			filter,
+			trackScreenViews: true,
+			trackOutgoingLinks: true,
+			trackAttributes: true,
+		});
+
+		await provider.initialize();
+
+		expect(constructorSpy).toHaveBeenCalledWith({
+			clientId: "client-id",
+			apiUrl: "https://openpanel.example.com",
+			debug: true,
+			filter,
+			trackAttributes: true,
+			trackOutgoingLinks: true,
+			trackScreenViews: true,
+		});
+	});
+
+	it("strips server-only options supplied by untyped callers", async () => {
+		const provider = new OpenPanelClientProvider({
+			clientId: "client-id",
+			clientSecret: "must-not-reach-browser-sdk",
+			disabled: true,
+			sdk: "custom",
+			sdkVersion: "1.0.0",
+			waitForProfile: true,
+		} as unknown as ConstructorParameters<typeof OpenPanelClientProvider>[0]);
+
+		await provider.initialize();
+
+		expect(constructorSpy).toHaveBeenCalledWith({
+			clientId: "client-id",
+			debug: false,
+			trackAttributes: false,
+			trackOutgoingLinks: false,
+			trackScreenViews: false,
+		});
+	});
+
+	it("validates clientId and respects disabled mode", async () => {
+		await expect(
+			new OpenPanelClientProvider({ clientId: "" }).initialize(),
+		).rejects.toThrow("clientId");
+
+		await new OpenPanelClientProvider({
+			clientId: "client-id",
+			enabled: false,
+		}).initialize();
+
+		expect(constructorSpy).not.toHaveBeenCalled();
+	});
+
+	it("maps identify traits to OpenPanel profile fields and properties", async () => {
+		const provider = new OpenPanelClientProvider({ clientId: "client-id" });
+		await provider.initialize();
+
+		await provider.identify("user-1", {
+			firstName: "Jane",
+			lastName: "Doe",
+			email: "jane@example.com",
+			avatar: "https://example.com/jane.png",
+			phone: "+31612345678",
+			plan: "pro",
+		});
+
+		expect(sdk.identify).toHaveBeenCalledWith({
+			profileId: "user-1",
+			firstName: "Jane",
+			lastName: "Doe",
+			email: "jane@example.com",
+			avatar: "https://example.com/jane.png",
+			properties: { phone: "+31612345678", plan: "pro" },
+		});
+	});
+
+	it("delivers identify and pageView calls made during initialization", async () => {
+		const provider = new OpenPanelClientProvider({ clientId: "client-id" });
+
+		const initializing = provider.initialize();
+		provider.identify("user-early", { email: "early@example.com" });
+		provider.pageView(
+			{ section: "early" },
+			{ page: { path: "/early", title: "Early" } },
+		);
+		await initializing;
+		await vi.waitFor(() => {
+			expect(sdk.identify).toHaveBeenCalledOnce();
+			expect(sdk.screenView).toHaveBeenCalledOnce();
+		});
+
+		expect(sdk.identify).toHaveBeenCalledWith({
+			profileId: "user-early",
+			email: "early@example.com",
+		});
+		expect(sdk.screenView).toHaveBeenCalledWith("/early", {
+			section: "early",
+			__path: "/early",
+			__title: "Early",
+			page: { path: "/early", title: "Early" },
+		});
+	});
+
+	it("tracks events with OpenPanel and Trakoo context", async () => {
+		const provider = new OpenPanelClientProvider({ clientId: "client-id" });
+		await provider.initialize();
+
+		await provider.track(
+			{
+				action: "checkout_started",
+				category: "conversion",
+				timestamp: 1_700_000_000_000,
+				userId: "user-1",
+				sessionId: "session-1",
+				properties: { amount: 42 },
+			},
+			{
+				page: {
+					path: "/checkout",
+					title: "Checkout",
+					referrer: "https://example.com/cart",
+					host: "example.com",
+					protocol: "https",
+					search: "?coupon=summer",
+				},
+				device: { type: "desktop", browser: "Firefox" },
+				utm: { source: "newsletter" },
+				user: { email: "jane@example.com", traits: { plan: "pro" } },
+			},
+		);
+
+		expect(sdk.track).toHaveBeenCalledWith("checkout_started", {
+			amount: 42,
+			category: "conversion",
+			__timestamp: "2023-11-14T22:13:20.000Z",
+			profileId: "user-1",
+			sessionId: "session-1",
+			__path: "/checkout",
+			__title: "Checkout",
+			__referrer: "https://example.com/cart",
+			page: {
+				path: "/checkout",
+				title: "Checkout",
+				referrer: "https://example.com/cart",
+				host: "example.com",
+				protocol: "https",
+				search: "?coupon=summer",
+			},
+			device: { type: "desktop", browser: "Firefox" },
+			utm: { source: "newsletter" },
+			user_email: "jane@example.com",
+			user_traits: { plan: "pro" },
+		});
+	});
+
+	it("maps page views, leaves pageLeave unsupported, and clears identity", async () => {
+		const provider = new OpenPanelClientProvider({ clientId: "client-id" });
+		await provider.initialize();
+
+		provider.pageView(
+			{ section: "docs" },
+			{ page: { path: "/docs", title: "Docs" } },
+		);
+		provider.pageLeave({ duration: 1000 });
+		provider.reset();
+
+		expect(sdk.screenView).toHaveBeenCalledWith("/docs", {
+			section: "docs",
+			__path: "/docs",
+			__title: "Docs",
+			page: { path: "/docs", title: "Docs" },
+		});
+		expect(sdk.track).not.toHaveBeenCalled();
+		expect(sdk.clear).toHaveBeenCalledTimes(1);
+	});
+});

--- a/test/openpanel-client-provider.test.ts
+++ b/test/openpanel-client-provider.test.ts
@@ -12,18 +12,27 @@ const { constructorSpy, sdk } = vi.hoisted(() => ({
 	},
 }));
 
-vi.mock("@openpanel/web", () => ({
-	OpenPanel: class {
-		identify = sdk.identify;
-		track = sdk.track;
-		screenView = sdk.screenView;
-		clear = sdk.clear;
-
-		constructor(config: unknown) {
-			constructorSpy(config);
+vi.mock("@openpanel/web", () => {
+	class OpenPanelBase {
+		track(name: string, properties?: Record<string, unknown>) {
+			return sdk.track(name, properties);
 		}
-	},
-}));
+	}
+
+	return {
+		OpenPanelBase,
+		OpenPanel: class extends OpenPanelBase {
+			identify = sdk.identify;
+			screenView = sdk.screenView;
+			clear = sdk.clear;
+
+			constructor(config: unknown) {
+				super();
+				constructorSpy(config);
+			}
+		},
+	};
+});
 
 describe("OpenPanelClientProvider", () => {
 	beforeEach(() => {

--- a/test/openpanel-client-provider.web-sdk.test.ts
+++ b/test/openpanel-client-provider.web-sdk.test.ts
@@ -1,0 +1,29 @@
+/** @vitest-environment jsdom */
+import { OpenPanelClientProvider } from "@/providers/openpanel/client.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("OpenPanelClientProvider with the web SDK", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("preserves the context path when tracking before a page view", async () => {
+		const fetchMock = vi.fn().mockResolvedValue({
+			status: 202,
+			text: vi.fn().mockResolvedValue(""),
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const provider = new OpenPanelClientProvider({ clientId: "client-id" });
+		await provider.initialize();
+		await provider.track(
+			{ action: "checkout_started", category: "conversion" },
+			{ page: { path: "/checkout" } },
+		);
+
+		expect(fetchMock).toHaveBeenCalledOnce();
+		const [, request] = fetchMock.mock.calls[0] as [string, RequestInit];
+		const body = JSON.parse(String(request.body));
+		expect(body.payload.properties.__path).toBe("/checkout");
+	});
+});

--- a/test/openpanel-server-provider.test.ts
+++ b/test/openpanel-server-provider.test.ts
@@ -1,0 +1,219 @@
+import { OpenPanelServerProvider } from "@/providers/openpanel/server.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { constructorSpy, sdk } = vi.hoisted(() => ({
+	constructorSpy: vi.fn(),
+	sdk: {
+		identify: vi.fn(),
+		track: vi.fn(),
+		clear: vi.fn(),
+	},
+}));
+
+vi.mock("@openpanel/sdk", () => ({
+	OpenPanel: class {
+		identify = sdk.identify;
+		track = sdk.track;
+		clear = sdk.clear;
+
+		constructor(config: unknown) {
+			constructorSpy(config);
+		}
+	},
+}));
+
+describe("OpenPanelServerProvider", () => {
+	beforeEach(() => {
+		constructorSpy.mockClear();
+		for (const mock of Object.values(sdk)) mock.mockReset();
+		sdk.track.mockResolvedValue(null);
+		sdk.identify.mockResolvedValue(null);
+	});
+
+	it("initializes synchronously once with authenticated server options", () => {
+		const filter = vi.fn(() => true);
+		const provider = new OpenPanelServerProvider({
+			clientId: "client-id",
+			clientSecret: "client-secret",
+			apiUrl: "https://openpanel.example.com",
+			debug: true,
+			filter,
+		});
+
+		provider.initialize();
+		provider.initialize();
+
+		expect(provider.name).toBe("OpenPanel-Server");
+		expect(constructorSpy).toHaveBeenCalledTimes(1);
+		expect(constructorSpy).toHaveBeenCalledWith({
+			clientId: "client-id",
+			clientSecret: "client-secret",
+			apiUrl: "https://openpanel.example.com",
+			debug: true,
+			filter,
+		});
+	});
+
+	it("validates both credentials and respects disabled mode", () => {
+		expect(() =>
+			new OpenPanelServerProvider({
+				clientId: "",
+				clientSecret: "secret",
+			}).initialize(),
+		).toThrow("clientId");
+		expect(() =>
+			new OpenPanelServerProvider({
+				clientId: "client-id",
+				clientSecret: "",
+			}).initialize(),
+		).toThrow("clientSecret");
+
+		new OpenPanelServerProvider({
+			clientId: "client-id",
+			clientSecret: "secret",
+			enabled: false,
+		}).initialize();
+		expect(constructorSpy).not.toHaveBeenCalled();
+	});
+
+	it("submits identify traits and clears retained identity before awaiting", async () => {
+		let resolveIdentify: (() => void) | undefined;
+		sdk.identify.mockReturnValue(
+			new Promise<void>((resolve) => {
+				resolveIdentify = resolve;
+			}),
+		);
+		const provider = new OpenPanelServerProvider({
+			clientId: "client-id",
+			clientSecret: "secret",
+		});
+		await provider.initialize();
+
+		const pending = provider.identify("user-a", {
+			firstName: "Jane",
+			email: "jane@example.com",
+			plan: "pro",
+		});
+
+		expect(sdk.identify).toHaveBeenCalledWith({
+			profileId: "user-a",
+			firstName: "Jane",
+			email: "jane@example.com",
+			properties: { plan: "pro" },
+		});
+		expect(sdk.clear).toHaveBeenCalledTimes(1);
+		resolveIdentify?.();
+		await pending;
+	});
+
+	it("never inherits an identified profile for later server events", async () => {
+		const provider = new OpenPanelServerProvider({
+			clientId: "client-id",
+			clientSecret: "secret",
+		});
+		await provider.initialize();
+		await provider.identify("user-a", { plan: "pro" });
+
+		await provider.track({
+			action: "anonymous_event",
+			category: "engagement",
+			properties: {},
+		});
+		await provider.track(
+			{ action: "known_event", category: "engagement", properties: {} },
+			{ user: { userId: "user-b" } },
+		);
+
+		expect(sdk.track).toHaveBeenNthCalledWith(1, "anonymous_event", {
+			category: "engagement",
+		});
+		expect(sdk.track).toHaveBeenNthCalledWith(2, "known_event", {
+			category: "engagement",
+			profileId: "user-b",
+		});
+	});
+
+	it("prefers event userId and maps full event context", async () => {
+		const provider = new OpenPanelServerProvider({
+			clientId: "client-id",
+			clientSecret: "secret",
+		});
+		await provider.initialize();
+
+		await provider.track(
+			{
+				action: "invoice_paid",
+				category: "conversion",
+				timestamp: 1_700_000_000_000,
+				userId: "event-user",
+				sessionId: "session-1",
+				properties: { amount: 42 },
+			},
+			{
+				page: {
+					path: "/billing",
+					title: "Billing",
+					host: "example.com",
+					protocol: "https",
+					search: "?invoice=123",
+				},
+				device: { userAgent: "test-agent" },
+				user: {
+					userId: "context-user",
+					email: "user@example.com",
+					traits: { plan: "pro" },
+				},
+			},
+		);
+
+		expect(sdk.track).toHaveBeenCalledWith("invoice_paid", {
+			amount: 42,
+			category: "conversion",
+			__timestamp: "2023-11-14T22:13:20.000Z",
+			profileId: "event-user",
+			sessionId: "session-1",
+			__path: "/billing",
+			__title: "Billing",
+			page: {
+				path: "/billing",
+				title: "Billing",
+				host: "example.com",
+				protocol: "https",
+				search: "?invoice=123",
+			},
+			device: { userAgent: "test-agent" },
+			user_email: "user@example.com",
+			user_traits: { plan: "pro" },
+		});
+	});
+
+	it("tracks screen views without retaining identity and leaves pageLeave unsupported", async () => {
+		const provider = new OpenPanelServerProvider({
+			clientId: "client-id",
+			clientSecret: "secret",
+		});
+		await provider.initialize();
+
+		await provider.pageView(
+			{ section: "docs" },
+			{
+				page: { path: "/docs", title: "Docs" },
+				user: { userId: "user-1" },
+			},
+		);
+		provider.pageLeave({ duration: 1000 });
+		provider.reset();
+		await provider.shutdown();
+
+		expect(sdk.track).toHaveBeenCalledOnce();
+		expect(sdk.track).toHaveBeenCalledWith("screen_view", {
+			section: "docs",
+			category: "navigation",
+			profileId: "user-1",
+			__path: "/docs",
+			__title: "Docs",
+			page: { path: "/docs", title: "Docs" },
+		});
+		expect(sdk.clear).toHaveBeenCalledTimes(2);
+	});
+});

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -6,17 +6,25 @@ describe("trakoo/providers exports", () => {
 	it("should export only client-safe providers from client entry", () => {
 		expect(ClientProviders.BaseAnalyticsProvider).toBeDefined();
 		expect(ClientProviders.PostHogClientProvider).toBeDefined();
+		expect(ClientProviders.OpenPanelClientProvider).toBeDefined();
 		expect(ClientProviders.VisitorsClientProvider).toBeDefined();
 		expect(
 			(ClientProviders as Record<string, unknown>).PostHogServerProvider,
+		).toBeUndefined();
+		expect(
+			(ClientProviders as Record<string, unknown>).OpenPanelServerProvider,
 		).toBeUndefined();
 	});
 
 	it("should export only server providers from server entry", () => {
 		expect(ServerProviders.BaseAnalyticsProvider).toBeDefined();
 		expect(ServerProviders.PostHogServerProvider).toBeDefined();
+		expect(ServerProviders.OpenPanelServerProvider).toBeDefined();
 		expect(
 			(ServerProviders as Record<string, unknown>).PostHogClientProvider,
+		).toBeUndefined();
+		expect(
+			(ServerProviders as Record<string, unknown>).OpenPanelClientProvider,
 		).toBeUndefined();
 	});
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,5 @@
-import { defineConfig } from "vite";
 import { resolve } from "node:path";
+import { defineConfig } from "vite";
 import dts from "vite-plugin-dts";
 
 // https://vitejs.dev/config/
@@ -18,7 +18,12 @@ export default defineConfig(({ mode }) => {
 				formats: ["es"],
 			},
 			rollupOptions: {
-				external: ["posthog-node", "posthog-js"],
+				external: [
+					"@openpanel/sdk",
+					"@openpanel/web",
+					"posthog-node",
+					"posthog-js",
+				],
 			},
 			ssr: false,
 		},

--- a/www/content/docs/(Getting Started)/installation.mdx
+++ b/www/content/docs/(Getting Started)/installation.mdx
@@ -55,6 +55,7 @@ Use `trakoo/providers/client` in browser bundles and `trakoo/providers/server` i
 | Provider | Client support | Server support | Extra install |
 |----------|----------------|----------------|---------------|
 | PostHog | Yes | Yes | `posthog-js posthog-node` |
+| OpenPanel | Yes | Yes | `@openpanel/web @openpanel/sdk` |
 | Bento | Yes, CDN script | Yes | `@bentonow/bento-node-sdk` for server |
 | Pirsch | Yes, CDN script | Yes | No extra package |
 | EmitKit | No | Yes | `@emitkit/js` |
@@ -66,6 +67,13 @@ Use `trakoo/providers/client` in browser bundles and `trakoo/providers/server` i
 
 ```bash
 pnpm install posthog-js posthog-node
+```
+
+</Tab>
+<Tab title="OpenPanel">
+
+```bash
+pnpm install @openpanel/web @openpanel/sdk
 ```
 
 </Tab>
@@ -117,6 +125,7 @@ Keep browser tokens public and server keys private.
 ```bash title=".env.local"
 VITE_POSTHOG_KEY=your-posthog-project-key
 VITE_POSTHOG_HOST=https://app.posthog.com
+VITE_OPENPANEL_CLIENT_ID=your-openpanel-client-id
 VITE_BENTO_SITE_UUID=your-bento-site-uuid
 VITE_VISITORS_TOKEN=your-visitors-token
 ```
@@ -127,9 +136,12 @@ VITE_VISITORS_TOKEN=your-visitors-token
 ```bash title=".env.local"
 NEXT_PUBLIC_POSTHOG_KEY=your-posthog-project-key
 NEXT_PUBLIC_POSTHOG_HOST=https://app.posthog.com
+NEXT_PUBLIC_OPENPANEL_CLIENT_ID=your-openpanel-client-id
 NEXT_PUBLIC_BENTO_SITE_UUID=your-bento-site-uuid
 NEXT_PUBLIC_VISITORS_TOKEN=your-visitors-token
 
+OPENPANEL_CLIENT_ID=your-openpanel-client-id
+OPENPANEL_CLIENT_SECRET=your-openpanel-client-secret
 POSTHOG_API_KEY=your-posthog-server-key
 BENTO_SITE_UUID=your-bento-site-uuid
 BENTO_PUBLISHABLE_KEY=your-bento-publishable-key
@@ -144,9 +156,12 @@ PIRSCH_ACCESS_KEY=pa_xxx
 ```bash title=".env"
 PUBLIC_POSTHOG_KEY=your-posthog-project-key
 PUBLIC_POSTHOG_HOST=https://app.posthog.com
+PUBLIC_OPENPANEL_CLIENT_ID=your-openpanel-client-id
 PUBLIC_BENTO_SITE_UUID=your-bento-site-uuid
 PUBLIC_VISITORS_TOKEN=your-visitors-token
 
+OPENPANEL_CLIENT_ID=your-openpanel-client-id
+OPENPANEL_CLIENT_SECRET=your-openpanel-client-secret
 POSTHOG_API_KEY=your-posthog-server-key
 BENTO_SITE_UUID=your-bento-site-uuid
 BENTO_PUBLISHABLE_KEY=your-bento-publishable-key

--- a/www/content/docs/providers/index.mdx
+++ b/www/content/docs/providers/index.mdx
@@ -11,6 +11,9 @@ Providers translate trakoo events into the APIs of the services you already use.
   <ProviderCard title="PostHog" href="/docs/providers/posthog" domain="posthog.com">
     Client and server product analytics, feature flags, and session replay
   </ProviderCard>
+  <ProviderCard title="OpenPanel" href="/docs/providers/openpanel" domain="openpanel.dev">
+    Client and server web and product analytics with optional session replay
+  </ProviderCard>
   <ProviderCard title="Bento" href="/docs/providers/bento" domain="bentonow.com">
     Client and server lifecycle/email automation for identified users
   </ProviderCard>
@@ -33,6 +36,7 @@ Providers translate trakoo events into the APIs of the services you already use.
 | Provider | Client import | Server import | Best for |
 |----------|---------------|---------------|----------|
 | PostHog | `PostHogClientProvider` | `PostHogServerProvider` | Product analytics across browser and backend |
+| OpenPanel | `OpenPanelClientProvider` | `OpenPanelServerProvider` | Open-source web and product analytics |
 | Bento | `BentoClientProvider` | `BentoServerProvider` | Identified lifecycle events and email automation |
 | Pirsch | `PirschClientProvider` | `PirschServerProvider` | Privacy-friendly page views and lightweight events |
 | EmitKit | — | `EmitKitServerProvider` | Notifications and activity channels |

--- a/www/content/docs/providers/meta.ts
+++ b/www/content/docs/providers/meta.ts
@@ -6,6 +6,7 @@ export default defineMeta({
 	pages: [
 		"index",
 		"posthog",
+		"openpanel",
 		"bento",
 		"pirsch",
 		"emitkit",

--- a/www/content/docs/providers/openpanel.mdx
+++ b/www/content/docs/providers/openpanel.mdx
@@ -1,0 +1,235 @@
+---
+title: OpenPanel
+description: Open-source web and product analytics for browser and server events.
+---
+
+[OpenPanel](https://openpanel.dev) combines web analytics and product analytics with support for custom events, user profiles, and optional session replay.
+
+## When to use it
+
+- You want open-source product analytics that work in the browser and on the server.
+- You need web analytics, custom events, profiles, and optional session replay in one provider.
+- You want to self-host OpenPanel or send events to OpenPanel Cloud.
+
+## Installation
+
+Install trakoo alongside the OpenPanel SDKs you need: `@openpanel/web` for the client and `@openpanel/sdk` for the server.
+
+```bash
+pnpm install trakoo @openpanel/web @openpanel/sdk
+```
+
+## Client-side usage
+
+Use `OpenPanelClientProvider` from `trakoo/providers/client`. Browser code needs only the public OpenPanel client ID.
+
+```typescript title="lib/analytics.ts"
+import { createClientAnalytics } from 'trakoo/client';
+import { OpenPanelClientProvider } from 'trakoo/providers/client';
+
+export const analytics = createClientAnalytics({
+  providers: [
+    new OpenPanelClientProvider({
+      clientId: import.meta.env.VITE_OPENPANEL_CLIENT_ID
+    })
+  ]
+});
+
+await analytics.track('signup_button_clicked', {
+  location: 'header',
+  variant: 'primary'
+});
+
+analytics.pageView({ section: 'pricing' });
+```
+
+The provider uses explicit trakoo calls by default. OpenPanel's automatic screen views, outgoing-link tracking, data-attribute tracking, and session replay remain disabled unless you enable their corresponding SDK options:
+
+```typescript title="lib/analytics.ts"
+new OpenPanelClientProvider({
+  clientId: import.meta.env.VITE_OPENPANEL_CLIENT_ID,
+  trackScreenViews: true,
+  trackOutgoingLinks: true,
+  trackAttributes: true,
+  sessionReplay: {
+    enabled: true,
+    maskAllInputs: true,
+    maskAllText: true
+  }
+})
+```
+
+:::warning[Keep secrets server-side]
+Never put an OpenPanel client secret in browser code. `OpenPanelClientProvider` intentionally does not accept `clientSecret`.
+:::
+
+## Server-side usage
+
+Use `OpenPanelServerProvider` from `trakoo/providers/server`. Server analytics is stateless, so pass user context with each attributed event.
+
+```typescript title="lib/server-analytics.ts"
+import { createServerAnalytics } from 'trakoo/server';
+import { OpenPanelServerProvider } from 'trakoo/providers/server';
+
+export const serverAnalytics = createServerAnalytics({
+  providers: [
+    new OpenPanelServerProvider({
+      clientId: process.env.OPENPANEL_CLIENT_ID!,
+      clientSecret: process.env.OPENPANEL_CLIENT_SECRET!
+    })
+  ]
+});
+
+await serverAnalytics.track('invoice_paid', {
+  invoiceId: 'inv_123',
+  amount: 4900
+}, {
+  userId: 'user_123',
+  user: {
+    email: 'jane@example.com',
+    traits: { plan: 'pro' }
+  }
+});
+
+serverAnalytics.shutdown();
+```
+
+The provider clears OpenPanel's local identity state after server-side `identify()` and on `shutdown()`, so it never reuses the identity from another request.
+
+## Identifying users
+
+Client identification persists until `analytics.reset()`. OpenPanel's standard `firstName`, `lastName`, `email`, and `avatar` traits are sent as profile fields. Other traits are stored as custom profile properties.
+
+```typescript title="lib/analytics.ts"
+analytics.identify('user_123', {
+  firstName: 'Jane',
+  lastName: 'Doe',
+  email: 'jane@example.com',
+  avatar: 'https://example.com/jane.png',
+  plan: 'pro'
+});
+```
+
+On the server, `identify()` updates the profile but does not persist that identity for later events. Continue to pass the profile ID on each tracked server event.
+
+```typescript title="lib/server-analytics.ts"
+await serverAnalytics.identify('user_123', {
+  email: 'jane@example.com',
+  plan: 'enterprise'
+});
+```
+
+Calling server-side `identify()` without traits still sends a profile payload with only the `profileId`.
+
+## Configuration
+
+Client options:
+
+<TypeTable
+  type={{
+    clientId: {
+      type: 'string',
+      required: true,
+      description: 'OpenPanel project client ID.'
+    },
+    apiUrl: {
+      type: 'string',
+      description: 'API URL for OpenPanel Cloud or a self-hosted instance.'
+    },
+    trackScreenViews: {
+      type: 'boolean',
+      default: 'false',
+      description: 'Automatically track browser navigation.'
+    },
+    trackOutgoingLinks: {
+      type: 'boolean',
+      default: 'false',
+      description: 'Automatically track external link clicks.'
+    },
+    trackAttributes: {
+      type: 'boolean',
+      default: 'false',
+      description: 'Enable OpenPanel data-attribute tracking.'
+    },
+    sessionReplay: {
+      type: 'object',
+      description: 'Configure optional OpenPanel session replay.'
+    },
+    filter: {
+      type: 'function',
+      description: 'Filter OpenPanel payloads before sending.'
+    },
+    debug: {
+      type: 'boolean',
+      default: 'false',
+      description: 'Enable provider and SDK debug logging.'
+    },
+    enabled: {
+      type: 'boolean',
+      default: 'true',
+      description: 'Set to false to disable the provider without removing it.'
+    }
+  }}
+/>
+
+Server options:
+
+<TypeTable
+  type={{
+    clientId: {
+      type: 'string',
+      required: true,
+      description: 'OpenPanel project client ID.'
+    },
+    clientSecret: {
+      type: 'string',
+      required: true,
+      description: 'Secret for authenticated server events.'
+    },
+    apiUrl: {
+      type: 'string',
+      description: 'API URL for OpenPanel Cloud or a self-hosted instance.'
+    },
+    filter: {
+      type: 'function',
+      description: 'Filter OpenPanel payloads before sending.'
+    },
+    debug: {
+      type: 'boolean',
+      default: 'false',
+      description: 'Enable provider and SDK debug logging.'
+    },
+    enabled: {
+      type: 'boolean',
+      default: 'true',
+      description: 'Set to false to disable the provider without removing it.'
+    }
+  }}
+/>
+
+## Method mapping
+
+| trakoo method | OpenPanel behavior |
+|---------------|--------------------|
+| `track()` | Sends the event name, properties, and trakoo context |
+| `identify()` | Creates or updates an OpenPanel profile |
+| `pageView()` | Sends OpenPanel's `screen_view` event |
+| `pageLeave()` | No-op; OpenPanel has no dedicated page-leave method |
+| `reset()` | Clears the browser or provider-local identity |
+
+## Resources
+
+<CardGroup>
+  <Card title="OpenPanel docs" href="https://openpanel.dev/docs" icon="book-open">
+    Official OpenPanel guides and API reference.
+  </Card>
+  <Card title="OpenPanel Web SDK" href="https://openpanel.dev/docs/sdks/web" icon="code">
+    Browser SDK options that the client provider forwards.
+  </Card>
+  <Card title="OpenPanel JavaScript SDK" href="https://openpanel.dev/docs/sdks/javascript" icon="server">
+    Server SDK configuration for backend tracking.
+  </Card>
+  <Card title="Routing" href="/docs/providers#routing" icon="route">
+    Send specific methods and events to OpenPanel.
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## Summary

- add first-class OpenPanel client and server providers using the official SDKs
- preserve explicit browser capture defaults and stateless server identity
- map tracking, identification, page views, reset, metadata, and full page context
- add optional dependencies, externalized builds, tests, documentation, and a minor changeset

## Safety and behavior

- browser configuration rejects `clientSecret` at the type level and strips server-only runtime options
- client identify and page-view calls made during initialization are queued
- server initialization is synchronous, and server identity is cleared in the same turn to avoid cross-request leakage
- `pageLeave` is intentionally a no-op because OpenPanel has no matching API

## Validation

- `pnpm test` — 160 tests passed
- `pnpm typecheck`
- `pnpm biome lint src test e2e www vite.config.ts package.json`
- `pnpm build`
- `pnpm build:docs`
- `git diff --check`

The root `pnpm lint` command also scans an unrelated linked worktree under `.worktrees/`; the scoped lint command above passes for this repository's changed surface.
